### PR TITLE
chore: move the sqlite stack off its end-of-life path and top up the rest

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,42 +5,42 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "5b7468c326d2f8a4f630056404ca0d291ade42918f4a3c6233618e724f39da8e"
+      sha256: a49d6cf99e8d8e7a8e93668d09ced0bbdb954d0b4fccc2f5f9241c6b87fad95c
       url: "https://pub.dev"
     source: hosted
-    version: "92.0.0"
+    version: "99.0.0"
   analysis_server_plugin:
     dependency: transitive
     description:
       name: analysis_server_plugin
-      sha256: "44adba4d74a2541173bad4c11531d2a4d22810c29c5ddb458a38e9f4d0e5eac7"
+      sha256: "3960b28ee740004df39f85d5ebfc91785f7a90e51fd7c9a185e86a36b2f581b4"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.4"
+    version: "0.3.14"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "70e4b1ef8003c64793a9e268a551a82869a8a96f39deb73dea28084b0e8bf75e"
+      sha256: "663efa951fb8a45e06f491223a604c93820598f20e6a99c25617a1576065e8b7"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.0"
+    version: "12.1.0"
   analyzer_buffer:
     dependency: transitive
     description:
       name: analyzer_buffer
-      sha256: ff4bd291778c7417fe53fe24ee0d0a1f1ffe281a2d4ea887e7094f16e36eace7
+      sha256: "445b77e2054fa3e8c8a8ef1b5e9e6b23bb8028fffd34b5e60eaef315b7750674"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.3"
   analyzer_plugin:
     dependency: transitive
     description:
       name: analyzer_plugin
-      sha256: "6645a029da947ffd823d98118f385d4bd26b54eb069c006b22e0b94e451814b5"
+      sha256: "0057a98d64d7bb872b0c87dff6e73d2c2d80c77156e7a03f127a26f8aa240649"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.11"
+    version: "0.14.8"
   ansicolor:
     dependency: "direct dev"
     description:
@@ -245,18 +245,18 @@ packages:
     dependency: "direct dev"
     description:
       name: dart_pre_commit
-      sha256: "2b1bbfb743412cf951fed41e27c693a1e1419e94c87d871531b3d3d5422ffd35"
+      sha256: "29e605eca7406533e3dc1f331e0cc20418f6f64540af5e366b51ada89a6576e6"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.1+1"
+    version: "6.1.3"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: a9c30492da18ff84efe2422ba2d319a89942d93e58eb0b73d32abe822ef54b7b
+      sha256: a4c1ccfee44c7e75ed80484071a5c142a385345e658fd8bd7c4b5c97e7198f98
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "3.1.8"
   device_info_plus:
     dependency: transitive
     description:
@@ -277,26 +277,26 @@ packages:
     dependency: "direct main"
     description:
       name: drift
-      sha256: "970cd188fddb111b26ea6a9b07a62bf5c2432d74147b8122c67044ae3b97e99e"
+      sha256: "84688491040b0ceb26575709a84d701c84ad4df4d8aff020adf6d85f155fb0dd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.31.0"
+    version: "2.34.2"
   drift_dev:
     dependency: "direct dev"
     description:
       name: drift_dev
-      sha256: "917184b2fb867b70a548a83bf0d36268423b38d39968c06cce4905683da49587"
+      sha256: "9cfff1576b49725da0d32c040651a41ae195e8c4af8d8da301593e41d7abc2f7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.31.0"
+    version: "2.34.0"
   drift_flutter:
     dependency: "direct main"
     description:
       name: drift_flutter
-      sha256: c07120854742a0cae2f7501a0da02493addde550db6641d284983c08762e60a7
+      sha256: "91acf4bee7c3c84467cba46455aa70e5292a3b889f4582645d74f2e5a8c106f2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.8"
+    version: "0.3.1"
   fake_async:
     dependency: transitive
     description:
@@ -375,10 +375,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_riverpod
-      sha256: "4e166be88e1dbbaa34a280bdb744aeae73b7ef25fdf8db7a3bb776760a3648e2"
+      sha256: "9255e1e3ad6e38906a1b4f8287678f95f378744c5b46b1985588543f3f19046e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.1"
+    version: "3.3.2"
   flutter_staggered_grid_view:
     dependency: "direct main"
     description:
@@ -497,10 +497,10 @@ packages:
     dependency: transitive
     description:
       name: injectable
-      sha256: "32b36a9d87f18662bee0b1951b81f47a01f2bf28cd6ea94f60bc5453c7bf598c"
+      sha256: "1da6399509e44ddb0d8a4a35291d7122c4efb5c625a9d733bf5e48d4a72e379e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.1+4"
+    version: "3.0.0"
   intl:
     dependency: "direct main"
     description:
@@ -637,6 +637,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  native_toolchain_c:
+    dependency: transitive
+    description:
+      name: native_toolchain_c
+      sha256: f9c168717100ae6d9fee9ffb0be379bf1f8b26b0f6bcbd4fdddcd931993a6a72
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.2"
   node_preamble:
     dependency: transitive
     description:
@@ -817,42 +825,42 @@ packages:
     dependency: transitive
     description:
       name: riverpod
-      sha256: "8c22216be8ad3ef2b44af3a329693558c98eca7b8bd4ef495c92db0bba279f83"
+      sha256: "17100416c51db7810c71a7bb2c34d1f881faa0074fd452afb0c4db6f8f126c76"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.3.2"
   riverpod_analyzer_utils:
     dependency: transitive
     description:
       name: riverpod_analyzer_utils
-      sha256: e55bc08c084a424e1bbdc303fe8ea75daafe4269b68fd0e0f6f1678413715b66
+      sha256: "3e275138862ccc22ed61444a1f9a840f753094c367f28f4123f50289cd204d68"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0-dev.9"
+    version: "1.0.0-dev.10"
   riverpod_annotation:
     dependency: "direct main"
     description:
       name: riverpod_annotation
-      sha256: "16471a1260b94e939394d78f1c63a9350936ac4a68c9fbdab40be47268c0b04f"
+      sha256: "674dbb26e2db3d9253166faf4758c796af14146b8fbcf5e7102bc8a04cd359b8"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.0.3"
   riverpod_generator:
     dependency: "direct dev"
     description:
       name: riverpod_generator
-      sha256: "6f9220534d7a353b53c875ea191a84d28cb4e52ac420a66a1bd7318329d977b0"
+      sha256: "54d790c3fee1ae281c448801bfdbfaa9fd961a9d3998494e0fcd9ee32184d7eb"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.3"
+    version: "4.0.4"
   riverpod_lint:
     dependency: "direct dev"
     description:
       name: riverpod_lint
-      sha256: "64e8debf5b719a37d48b9785dd595d34133fdcd84b8fd07157a621c54ab2156f"
+      sha256: "166f29492228dc471b6fe294092560ccd5545ed15c9fc155622455b58b2451a9"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "3.1.4"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -978,30 +986,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.2"
+  sqlcipher_flutter_libs:
+    dependency: transitive
+    description:
+      name: sqlcipher_flutter_libs
+      sha256: "38d62d659d2fb8739bf25a42c9a350d1fdd6c29a5a61f13a946778ec75d27929"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.0+eol"
   sqlite3:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: "3145bd74dcdb4fd6f5c6dda4d4e4490a8087d7f286a14dee5d37087290f0f8a2"
+      sha256: c73fd75df1332d76a6257f4823ae4df9c791f522b97e4a60cbcad214de1becf4
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.4"
+    version: "3.5.0"
   sqlite3_flutter_libs:
     dependency: transitive
     description:
       name: sqlite3_flutter_libs
-      sha256: eeb9e3a45207649076b808f8a5a74d68770d0b7f26ccef6d5f43106eee5375ad
+      sha256: "3ed7553eee7bb368f8950f58ba29f634e06e813c029aff6a0d60862b96de8454"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.42"
+    version: "0.6.0+eol"
   sqlparser:
     dependency: transitive
     description:
       name: sqlparser
-      sha256: "337e9997f7141ffdd054259128553c348635fa318f7ca492f07a4ab76f850d19"
+      sha256: "40bdddb306a727be9ce510bd2d2b9a6c9db6c586d846ef7b22e3990a2b24f02d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.43.1"
+    version: "0.44.5"
   stack_trace:
     dependency: transitive
     description:
@@ -1046,74 +1062,74 @@ packages:
     dependency: transitive
     description:
       name: syncfusion_flutter_core
-      sha256: "1997047ac91baa1e3c626394fa77e56d86bb00ab0d5de755ca73d617500aa948"
+      sha256: "4e5825c8b0cbbc9ec66140dcbc0948d136bb8c0a9ac8b00bd762f1ed520ca4e8"
       url: "https://pub.dev"
     source: hosted
-    version: "34.1.31"
+    version: "34.1.32"
   syncfusion_flutter_pdf:
     dependency: transitive
     description:
       name: syncfusion_flutter_pdf
-      sha256: "67d0acff1d090443f76b07bd6b4aa3f213839e1a39ba6597752d0ec9e75a5cf2"
+      sha256: d64db21b23ce15ac6950b6731b996bad95f8fb2a15bcc777574fc636c80c2612
       url: "https://pub.dev"
     source: hosted
-    version: "34.1.31"
+    version: "34.1.32"
   syncfusion_flutter_pdfviewer:
     dependency: "direct main"
     description:
       name: syncfusion_flutter_pdfviewer
-      sha256: "71c9a423eb4df55d07668e1361d9da80d94daa279b041142192ae4abc5f6c85c"
+      sha256: c4aae8b061901c9fed25426e256786674708261a6a79ef732c50798338eb1f0d
       url: "https://pub.dev"
     source: hosted
-    version: "34.1.31"
+    version: "34.1.32"
   syncfusion_flutter_signaturepad:
     dependency: transitive
     description:
       name: syncfusion_flutter_signaturepad
-      sha256: caa3ba75688d8d813ff4a850ca762883cd7c0d6e6542fc1b3c73ebf7b26d27e6
+      sha256: "961875cbf85a1cbeadade505bcbb39c0e5c8276b287969ca10f9e192da97da36"
       url: "https://pub.dev"
     source: hosted
-    version: "34.1.31"
+    version: "34.1.32"
   syncfusion_pdfviewer_linux:
     dependency: transitive
     description:
       name: syncfusion_pdfviewer_linux
-      sha256: "2de6aed4114a467ba2cd47c780d044d162176df6cf4f84733abf4c24a24432f7"
+      sha256: "7cd44096fda88f09f8657db4ab38a8f26694a1c2b3fcc8160265477ab39c29b9"
       url: "https://pub.dev"
     source: hosted
-    version: "34.1.31"
+    version: "34.1.32"
   syncfusion_pdfviewer_macos:
     dependency: transitive
     description:
       name: syncfusion_pdfviewer_macos
-      sha256: ffb2762f3f2f5c950adba2a97b392bc700a17439ed017b7e82dd00bdb093d06e
+      sha256: "7ef050ef83b506bb62981027e1fe7b4b9de15a72c916040e21b265a254ae3e45"
       url: "https://pub.dev"
     source: hosted
-    version: "34.1.31"
+    version: "34.1.32"
   syncfusion_pdfviewer_platform_interface:
     dependency: transitive
     description:
       name: syncfusion_pdfviewer_platform_interface
-      sha256: "483021222aa63d0fad4818e362b3cf9e2315ca4e6ae54df1c5b564e3be28a49a"
+      sha256: "27d17d70ba1dd06d6bc5b69ebefbad6d184d062d6f4547c6f30bfa0046c44883"
       url: "https://pub.dev"
     source: hosted
-    version: "34.1.31"
+    version: "34.1.32"
   syncfusion_pdfviewer_web:
     dependency: transitive
     description:
       name: syncfusion_pdfviewer_web
-      sha256: "7d3a44af81a30c96cbd862edb16e7c4b1b4831c5d6b66b8d3dce17e7427eee1f"
+      sha256: "904fbfe81ac9d4ef2fb981ca16ae28f49f821b4ba3a88ea867c71e960f90144c"
       url: "https://pub.dev"
     source: hosted
-    version: "34.1.31"
+    version: "34.1.32"
   syncfusion_pdfviewer_windows:
     dependency: transitive
     description:
       name: syncfusion_pdfviewer_windows
-      sha256: "1bf15a8e00d433f5049e24a8ec393e6a1b4bd204b5e9f56c6a12a157edeb818c"
+      sha256: "6d6535cb1b5e98285adef1e66136bf5cfcbdb29a45c0214d10d60cba7b0aae6e"
       url: "https://pub.dev"
     source: hosted
-    version: "34.1.31"
+    version: "34.1.32"
   term_glyph:
     dependency: transitive
     description:
@@ -1158,10 +1174,10 @@ packages:
     dependency: "direct main"
     description:
       name: upgrader
-      sha256: "6282524d4b664e48e24736ce343eedd115dcc1ce79198fc0bd46f14692e1f05e"
+      sha256: "7efb17f21ca9d3ee5c186d084dd76a5b9740f68dc297ef9f79ee21eb0235c8d0"
       url: "https://pub.dev"
     source: hosted
-    version: "13.5.0"
+    version: "13.6.0"
   url_launcher:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,20 +9,20 @@ environment:
   sdk: ^3.9.0
 
 dependencies:
-  drift: ^2.31.0
-  drift_flutter: ^0.2.8
+  drift: ^2.34.2
+  drift_flutter: ^0.3.1
   flutter:
     sdk: flutter
   flutter_advanced_drawer: ^1.5.0
   flutter_markdown_plus: ^1.0.12
-  flutter_riverpod: ^3.3.1
-  riverpod_annotation: ^4.0.2
+  flutter_riverpod: ^3.3.2
+  riverpod_annotation: ^4.0.3
   flutter_staggered_grid_view: ^0.7.0
   go_router: ^17.3.0
   path_provider: ^2.1.6
   shared_preferences: ^2.5.5
-  syncfusion_flutter_pdfviewer: ^34.1.31
-  upgrader: ^13.5.0
+  syncfusion_flutter_pdfviewer: ^34.1.32
+  upgrader: ^13.6.0
   url_launcher: ^6.3.2
   reorderable_grid: ^1.0.13
   collection: ^1.19.1
@@ -34,14 +34,14 @@ dependencies:
 dev_dependencies:
   ansicolor: ^2.0.3
   build_runner: ^2.15.1
-  dart_pre_commit: ^6.1.1+1
-  drift_dev: ^2.31.0
+  dart_pre_commit: ^6.1.3
+  drift_dev: ^2.34.0
   flutter_test:
     sdk: flutter
   git_hooks: ^1.0.2
   flutter_lints: ^6.0.0
-  riverpod_generator: ^4.0.3
-  riverpod_lint: ^3.1.3
+  riverpod_generator: ^4.0.4
+  riverpod_lint: ^3.1.4
   mocktail: ^1.0.5
 
 flutter:


### PR DESCRIPTION
## Per què

`sqlite3_flutter_libs` està deprecat: des de la **0.6.0 el paquet ja no fa res**, i des de **drift 2.32** (sobre `sqlite3` 3.x) el SQLite s'empaqueta automàticament. Estàvem a drift 2.31 / sqlite3 2.x, la branca que upstream ha declarat morta.

**No hi havia res trencat.** El requisit de 16 KB page sizes de Play ja el complíem (va entrar a `sqlite3_flutter_libs` 0.5.25 i n'usàvem la 0.5.42) i cap changelog de drift 2.32→2.34 corregeix res de correctesa o pèrdua de dades que ens faltés. Això és **manteniment**, no una correcció.

## Què puja

```
drift                        2.31.0   -> 2.34.2
drift_flutter                0.2.8    -> 0.3.1
sqlite3 (transitiu)          2.9.4    -> 3.5.0
drift_dev                    2.31.0   -> 2.34.0
flutter_riverpod             3.3.1    -> 3.3.2
riverpod_annotation          4.0.2    -> 4.0.3
riverpod_generator           4.0.3    -> 4.0.4
riverpod_lint                3.1.3    -> 3.1.4
dart_pre_commit              6.1.1+1  -> 6.1.3
syncfusion_flutter_pdfviewer 34.1.31  -> 34.1.32
upgrader                     13.5.0   -> 13.6.0
```

Pujar drift arrossega l'`analyzer` de 9 a 12, i això és el que obliga a moure les eines de Riverpod: si es deixen quietes, resolen a **versions prerelease**.

## Per què no pugem més

Dos sostres, cap dels dos a les nostres mans:

1. **El SDK de Flutter fixa `meta` 1.18.0**, mentre `analyzer >=13.1` demana `^1.18.3` → `build_runner >=2.15.2` és inassolible.
2. **`riverpod_generator` 4.0.6 es contradiu a si mateix**: demana `analyzer ^13` però arrossega `riverpod_analyzer_utils 1.0.0-dev.10`, que exigeix `^12`. Això encadena `riverpod_lint` (≤3.1.4, que fixa `riverpod` 3.3.2 i per tant bloqueja `flutter_riverpod` 3.4.1), `riverpod_annotation` (fixat a 4.0.3 pel generador) i `drift_dev` (≥2.34.1 vol analyzer 13).

`intl` es queda a `any`, tal com prescriu la documentació de Flutter.

## Verificació

- `dart run build_runner build` → **codi generat byte a byte idèntic**
- `flutter analyze` net · `dart format --set-exit-if-changed` net
- **543 tests passen**, inclosos els 3 que construeixen una base de dades real
- APK de release compila
- Al dispositiu: **instal·lació neta** (crea i sembra la BD) i **instal·lació sobre dades existents** — sense cap error, amb el catàleg llegint-se correctament

🤖 Generated with [Claude Code](https://claude.com/claude-code)