### PR TITLE
chore: bump checkout action, drop dead signing line, document newDsl

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,7 +12,7 @@ jobs:
   flutter-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: subosito/flutter-action@v2
         with:
           channel: stable

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -42,10 +42,6 @@ android {
     }
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now,
-            // so `flutter run --release` works.
-            signingConfig = signingConfigs.debug
             signingConfig = signingConfigs.release
         }
     }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -5,5 +5,9 @@ android.useAndroidX=true
 # Alternative permanent fix: set PUB_CACHE env var to D:\pub-cache
 kotlin.incremental=false
 android.builtInKotlin=true
-# This newDsl flag was added automatically by Flutter migrator
+# Must stay false until Flutter's Gradle plugin migrates to AGP's new DSL.
+# With newDsl=true, AGP 9 exposes only the new interface and applying
+# dev.flutter.flutter-gradle-plugin fails: ApplicationExtensionImpl cannot be
+# cast to AbstractAppExtension. Verified against Flutter 3.47 (2026-08-16).
+# The opt-out disappears in AGP 10, so this blocks that upgrade.
 android.newDsl=false


### PR DESCRIPTION
Three loose ends left over from the AGP 9 migration in #8.

## `actions/checkout` v4 → v5

GitHub runners already force v4 onto Node.js 24 and annotate every run with the Node.js 20 deprecation notice.

## Dead signing line

`buildTypes.release` had two consecutive `signingConfig` assignments:

```groovy
signingConfig = signingConfigs.debug
signingConfig = signingConfigs.release
```

The first never had any effect — it was overwritten on the next line. The `TODO` comment above it claimed we sign release builds with debug keys, which stopped being true when the `key.properties` signing config was added.

Verified with `jarsigner` that the release bundle is still signed by the real key (`CN=benx, O=isdabenx`) and the output is the same size to the byte.

## `android.newDsl` — blocked upstream, now documented

I tried flipping it to `true`. It cannot work yet:

```
Failed to apply plugin 'dev.flutter.flutter-gradle-plugin'.
> class ApplicationExtensionImpl$AgpDecorated_Decorated cannot be cast to
  class com.android.build.gradle.AbstractAppExtension
```

With `newDsl=true` AGP 9 exposes only the new DSL interface, and **Flutter's own Gradle plugin still reads the old one**. Flutter's error handler says to update Flutter or opt out — and 3.47 is already the latest stable, so there is nothing to update to.

The practical consequence: **AGP 10 readiness is blocked upstream on Flutter, not on our build logic.** The `newDsl` opt-out disappears in AGP 10, so this needs to be resolved on Flutter's side before that upgrade is possible. Written into `gradle.properties` so nobody has to rediscover it.

## Verification

- `flutter build apk --debug` — clean, no warnings
- `flutter build appbundle --release` — clean, 82.2MB, signature verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)